### PR TITLE
Fix environment variable substitution

### DIFF
--- a/inducker-gallery-dl
+++ b/inducker-gallery-dl
@@ -9,7 +9,7 @@ docker build --tag inducker-gallery-dl - <<'DOCKERFILE'
 
   RUN pip install --user gallery-dl
 
-  ENV PATH /home/deploy/.local/bin:${PATH}
+  ENV PATH /home/deploy/.local/bin:$PATH
 
   CMD ["/bin/bash"]
 DOCKERFILE

--- a/inducker-gallery-dl
+++ b/inducker-gallery-dl
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker build --tag inducker-gallery-dl - <<DOCKERFILE
+docker build --tag inducker-gallery-dl - <<'DOCKERFILE'
   FROM python:alpine
 
   RUN adduser -S deploy
@@ -9,7 +9,7 @@ docker build --tag inducker-gallery-dl - <<DOCKERFILE
 
   RUN pip install --user gallery-dl
 
-  ENV PATH /home/deploy/.local/bin:$PATH
+  ENV PATH /home/deploy/.local/bin:${PATH}
 
   CMD ["/bin/bash"]
 DOCKERFILE


### PR DESCRIPTION
Using a heredoc meant that the value of `$PATH` env variable was substituted instead of referencing it.
